### PR TITLE
Add an example deployment yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ docker push pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION
 In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
 
 ```bash
-senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION IMAGENAME IMAGEVERSION example-mint-bucket-eu-west-1
+senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.stups.example.org/<your-team>/gpu-hello-world IMAGEVERSION example-mint-bucket-eu-west-1
 ```
 
 This assumes:
-* A Docker image `IMAGENAME:IMAGEVERSION` exists in the Pierone registry. For example: `pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION`.
+* A Docker image `pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION` exists in the Pierone registry (where `<your-team>` indicates the team for which the image was pushed).
 * The Mint bucket for credential storage is at `example-mint-bucket-eu-west-1`
 
 ### Checking the output

--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ This assumes:
 * The Pierone registry is found at `pierone.example.com`
 * A Docker image with version `IMAGEVERSION` exists at the registry for team to which the logged-in user belongs.
 * The Mint bucket for credential storage is at `example-mint-bucket-eu-west-1`
+
+### Checking the output
+The output of the `nvidia-smi` command is written to `/var/log/application.log` and this can be checked by logging into the instance using `piu`. Alternatively, a log provider such as [Scalyr](https://www.scalyr.com) can be used.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,28 @@ This application represents a basic GPU example to demonstrate the use of GPU in
 
 This is discussed in the STUPS User Guide [here](http://stups.readthedocs.io/en/latest/user-guide/gpu-hello-world.html).
 
-## Deployment
+## Building and pushing the Docker image
 
-### Creating the Cloud Formation Stack using Senza
+In order to build the Docker image, an `scm-source.json` file is required to build the Docker image for this project. The [STUPS documentation](http://stups.readthedocs.io/en/latest/user-guide/application-development.html#scm-source-json) provides a description of the file and alternative ways to generate it. One method is to use the `scm-source` [Python package](https://pypi.python.org/pypi/scm-source):
+```bash
+pip3 install --upgrade scm-source
+scm-source
+```
+
+Now the Docker image for this example can be built by running the following command:
+```bash
+docker build -t pierone.example.com/teamname/gpu-hello-world:IMAGEVERSION .
+```
+where `IMAGEVERSION` represents the version tag to associate with the Docker images.
+
+The built image can then be pushed to the PierOne registry:
+```bash
+docker push pierone.example.com/teamname/gpu-hello-world:IMAGEVERSION
+```
+(running the `pierone login` command may be required)
+
+
+## Creating the Cloud Formation Stack using Senza
 In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ This application represents a basic GPU example to demonstrate the use of GPU in
 
 This is discussed in the STUPS User Guide [here](http://stups.readthedocs.io/en/latest/user-guide/gpu-hello-world.html).
 
-## Building and pushing the Docker image
+## Notes on a GPU-enabled Senza definition
+
+The file `deply-definition.yaml` contains the following options that may require some explanation:
+- The instance type is specified as `p2.xlarge` to allow for GPU computing. All `p2.*` and `g2.*` instances are supported, but `p2.*` instances are recommended from a performance point of view.
+- A Spot Price for the instances has been specified.
+- The Security Group and IAM Role definitions have been specified in the YAML file. This will create them at each deployment and does not require that they be manually created using e.g. `stups init`.
+
+## Deployment
+### Building and pushing the Docker image
 
 In order to build the Docker image, an `scm-source.json` file is required to build the Docker image for this project. The [STUPS documentation](http://stups.readthedocs.io/en/latest/user-guide/application-development.html#scm-source-json) provides a description of the file and alternative ways to generate it. One method is to use the `scm-source` [Python package](https://pypi.python.org/pypi/scm-source):
 ```bash
@@ -25,11 +33,11 @@ docker push pierone.example.com/teamname/gpu-hello-world:IMAGEVERSION
 (running the `pierone login` command may be required)
 
 
-## Creating the Cloud Formation Stack using Senza
+### Creating the Cloud Formation Stack using Senza
 In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
 
 ```bash
-senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.example.com IMAGEVERSION example-mint-bucket-eu-west-1
+senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.example.com IMAGEVERSION example-mint-bucket-eu-west-1 --region=eu-west-1
 ```
 
 This assumes:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ scm-source
 
 Now the Docker image for this example can be built by running the following command:
 ```bash
-docker build -t pierone.example.com/teamname/gpu-hello-world:IMAGEVERSION .
+docker build -t pierone.stups.example.org/teamname/gpu-hello-world:IMAGEVERSION .
 ```
 where `IMAGEVERSION` represents the version tag to associate with the Docker images.
 
 The built image can then be pushed to the PierOne registry:
 ```bash
-docker push pierone.example.com/teamname/gpu-hello-world:IMAGEVERSION
+docker push pierone.stups.example.org/<your-team>teamname/gpu-hello-world:IMAGEVERSION
 ```
 (running the `pierone login` command may be required)
 
@@ -37,11 +37,11 @@ docker push pierone.example.com/teamname/gpu-hello-world:IMAGEVERSION
 In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
 
 ```bash
-senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.example.com IMAGEVERSION example-mint-bucket-eu-west-1 --region=eu-west-1
+senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.stups.example.org IMAGEVERSION example-mint-bucket-eu-west-1 --region=eu-west-1
 ```
 
 This assumes:
-* The Pierone registry is found at `pierone.example.com`
+* The Pierone registry is found at `pierone.stups.example.org`
 * A Docker image with version `IMAGEVERSION` exists at the registry for team to which the logged-in user belongs.
 * The Mint bucket for credential storage is at `example-mint-bucket-eu-west-1`
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # STUPS GPU Hello World example
 
-This application represents a basic GPU example to demonstrate the use of GPU instances using STUPS. 
+This application represents a basic GPU example to demonstrate the use of GPU instances using STUPS.
 
 This is discussed in the STUPS User Guide [here](http://stups.readthedocs.io/en/latest/user-guide/gpu-hello-world.html).
+
+## Deployment
+
+### Creating the Cloud Formation Stack using Senza
+In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
+
+```bash
+senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.example.com IMAGEVERSION example-mint-bucket-eu-west-1
+```
+
+This assumes:
+* The Pierone registry is found at `pierone.example.com`
+* A Docker image with version `IMAGEVERSION` exists at the registry for team to which the logged-in user belongs.
+* The Mint bucket for credential storage is at `example-mint-bucket-eu-west-1`

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ scm-source
 
 Now the Docker image for this example can be built by running the following command:
 ```bash
-docker build -t pierone.stups.example.org/teamname/gpu-hello-world:IMAGEVERSION .
+docker build -t pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION .
 ```
 where `IMAGEVERSION` represents the version tag to associate with the Docker images.
 
 The built image can then be pushed to the PierOne registry:
 ```bash
-docker push pierone.stups.example.org/<your-team>teamname/gpu-hello-world:IMAGEVERSION
+docker push pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION
 ```
 (running the `pierone login` command may be required)
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ docker push pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION
 In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
 
 ```bash
-senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.stups.example.org IMAGEVERSION example-mint-bucket-eu-west-1
+senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION IMAGENAME IMAGEVERSION example-mint-bucket-eu-west-1
 ```
 
 This assumes:
-* The Pierone registry is found at `pierone.stups.example.org`
-* A Docker image with version `IMAGEVERSION` exists at the registry for team to which the logged-in user belongs.
+* A Docker image `IMAGENAME:IMAGEVERSION` exists in the Pierone registry. For example: `pierone.stups.example.org/<your-team>/gpu-hello-world:IMAGEVERSION`.
 * The Mint bucket for credential storage is at `example-mint-bucket-eu-west-1`
 
 ### Checking the output

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker push pierone.stups.example.org/<your-team>teamname/gpu-hello-world:IMAGEV
 In order to deploy the stack with version `STACKVERSION`, run the following `senza` command:
 
 ```bash
-senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.stups.example.org IMAGEVERSION example-mint-bucket-eu-west-1 --region=eu-west-1
+senza create --region=eu-west-1 deploy-definition.yaml STACKVERSION pierone.stups.example.org IMAGEVERSION example-mint-bucket-eu-west-1
 ```
 
 This assumes:

--- a/deploy-definition.yaml
+++ b/deploy-definition.yaml
@@ -20,15 +20,55 @@ SenzaComponents:
   # will create a launch configuration and auto scaling group with scaling triggers
   - AppServer:
       Type: Senza::TaupageAutoScalingGroup
+
+      # p2.* or g2.* instances are required for GPU computing. p2.* instances are recommended.
       InstanceType: p2.xlarge
-      SpotPrice: 10.0
+      # specify a spot price for the GPU instances
+      SpotPrice: 0.972
+      # Create a security group and IAM role at start up
       SecurityGroups:
-        - app-gpu-hello-world
+      - Fn::GetAtt:
+        - GPUHelloWorldSecurityGroup
+        - GroupId
       IamRoles:
-        - app-gpu-hello-world
+        - Ref: GPUHelloWorldRole
+
       AssociatePublicIpAddress: false # change for standalone deployment in default VPC
       TaupageConfig:
         application_version: "{{Arguments.ImageVersion}}"
         runtime: Docker
         source: "{{Arguments.PieroneRegistry}}/{{AccountInfo.TeamID}}/gpu-hello-world:{{Arguments.ImageVersion}}"
         mint_bucket: "{{Arguments.MintBucket}}"
+
+Resources:
+  GPUHelloWorldSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: GPU Hello World Security Group
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+
+  GPUHelloWorldRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: ec2.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: AmazonS3ReadOnlyAccess
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action:
+            - s3:GetObject
+            Sid: "AllowMintRead"
+            Resource: ["arn:aws:s3:::{{Arguments.MintBucket}}/*"]

--- a/deploy-definition.yaml
+++ b/deploy-definition.yaml
@@ -1,0 +1,34 @@
+
+# basic information for generating and executing this definition
+SenzaInfo:
+  StackName: gpu-hello-world
+  Parameters:
+    - PieroneRegistry:
+        Description: "The Pierone registry hostname."
+    - ImageVersion:
+        Description: "Docker image version of gpu-hello-world."
+    - MintBucket:
+        Description: "The Mint bucket to use for credential storage"
+
+# a list of senza components to apply to the definition
+SenzaComponents:
+
+  # this basic configuration is required for the other components
+  - Configuration:
+      Type: Senza::StupsAutoConfiguration # auto-detect network setup
+
+  # will create a launch configuration and auto scaling group with scaling triggers
+  - AppServer:
+      Type: Senza::TaupageAutoScalingGroup
+      InstanceType: p2.xlarge
+      SpotPrice: 10.0
+      SecurityGroups:
+        - app-gpu-hello-world
+      IamRoles:
+        - app-gpu-hello-world
+      AssociatePublicIpAddress: false # change for standalone deployment in default VPC
+      TaupageConfig:
+        application_version: "{{Arguments.ImageVersion}}"
+        runtime: Docker
+        source: "{{Arguments.PieroneRegistry}}/{{AccountInfo.TeamID}}/gpu-hello-world:{{Arguments.ImageVersion}}"
+        mint_bucket: "{{Arguments.MintBucket}}"

--- a/deploy-definition.yaml
+++ b/deploy-definition.yaml
@@ -3,10 +3,10 @@
 SenzaInfo:
   StackName: gpu-hello-world
   Parameters:
-    - PieroneRegistry:
-        Description: "The Pierone registry hostname."
+    - DockerImage:
+        Description: "The full Pierone path of the Docker image to use"
     - ImageVersion:
-        Description: "Docker image version of gpu-hello-world."
+        Description: "Docker image version of gpu-hello-world"
     - MintBucket:
         Description: "The Mint bucket to use for credential storage"
 
@@ -37,7 +37,7 @@ SenzaComponents:
       TaupageConfig:
         application_version: "{{Arguments.ImageVersion}}"
         runtime: Docker
-        source: "{{Arguments.PieroneRegistry}}/{{AccountInfo.TeamID}}/gpu-hello-world:{{Arguments.ImageVersion}}"
+        source: "{{Arguments.DockerImage}}:{{Arguments.ImageVersion}}"
         mint_bucket: "{{Arguments.MintBucket}}"
 
 Resources:


### PR DESCRIPTION
I have added an example deployment file. Note that the Pierone registry and mint bucket need to be specified. Still to be done:

- [x] Document the options in the YAML file (e.g. spot instances)
- [x] Describe the docker build step in the README.
- [x] Describe the stack creation step in the README.
